### PR TITLE
Corrected the name of the argument passed

### DIFF
--- a/data.Rmd
+++ b/data.Rmd
@@ -144,7 +144,7 @@ spec_explicit
 
 The accepted variable types are: `integer`, `character`, `logical`, `double`, `numeric`, `factor`, `Date` and `POSIXct`.
 
-Then, when reading using `spark_read_csv()`, you can pass `col_spec_1` to the `columns` argument to match the names and types of the original file. This helps improve performance since Spark will not have to figure out the column types.
+Then, when reading using `spark_read_csv()`, you can pass `spec_with_r` to the `columns` argument to match the names and types of the original file. This helps improve performance since Spark will not have to figure out the column types.
 
 ```{r data-schema-read-csv}
 spark_read_csv(sc, "data-csv/", columns = spec_with_r)


### PR DESCRIPTION
Corrected the text describing the name of the argument passed to function spark_read_csv(), from `col_spec_1` to `spec_with_r`